### PR TITLE
Fixing tests.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const config = require('./config');
+const log = require('./log');
+const app = require('express')();
+const server = require('http').Server(app); // eslint-disable-line new-cap
+const io = require('socket.io')(server);
+
+app.get('/', (req, res) => {
+	res.sendStatus(200);
+});
+
+const HEARTBEAT_TIMEOUT = 15 * 1000;
+const authenticatedSockets = new WeakSet();
+
+let client = null;
+let chatClient = null;
+
+/**
+ * Initializes the socket.io server.
+ * @param {*} twitchClient The chat client to communicate with.
+ */
+function setupServer(twitchClient) {
+	client = twitchClient;
+	chatClient = twitchClient.chatClient;
+
+	io.on('connection', socket => {
+		log.trace('Socket %s connected.', socket.id);
+
+		socket.on('authenticate', (key, fn) => {
+			log.debug('Socket %s authenticating with key "%s"', socket.id, key);
+
+			if (authenticatedSockets.has(socket)) {
+				log.debug('Already authenticated');
+				fn('already authenticated');
+				return;
+			}
+
+			if (key === config.get('secretKey')) {
+				log.debug('Accepted key');
+				setupAuthenticatedSocket(socket);
+				fn(null);
+			} else {
+				log.info('Rejected key "%s"', key);
+				fn('invalid key');
+			}
+		});
+	});
+
+	log.info('Socket.IO server initialized');
+
+	server.listen(config.get('port'));
+	log.info('Streen running on http://localhost:%s', config.get('port'));
+}
+
+module.exports = {app, io, HEARTBEAT_TIMEOUT, setupServer};
+
+function setupAuthenticatedSocket(socket) {
+	authenticatedSockets.add(socket);
+
+	/**
+	 * Join a Twitch chat channel.
+	 * @param {String} channel - The name of the channel to join. Do not include a leading "#" character.
+	 * @param {Function} fn - The callback to execute after successfully joining the channel.
+	 */
+	socket.on('join', (channel, fn) => {
+		// callback optional
+		fn = fn || (() => {});
+
+		// NOTE 2/1/2017: Rooms are only left when the socket itself is closed. Is this okay? Is this a leak?
+		// Have the socket join the namespace for the channel in order to receive messages.
+		const roomName = `channel:${channel}`;
+		if (Object.keys(socket.rooms).indexOf(roomName) < 0) {
+			log.trace('Socket %s joined room:', socket.id, roomName);
+			socket.join(roomName);
+		}
+
+		client.resetHeartbeat(channel);
+
+		if (chatClient.channels.indexOf(`#${channel}`) >= 0) {
+			// Already in channel, invoke callback with the name
+			fn(null, channel);
+		} else {
+			chatClient.join(channel).then(() => {
+				fn(null, null);
+			}).catch(error => {
+				log.error(`Error attempting to join "${channel}" from join command.\n\t`, error);
+				fn(error);
+			});
+		}
+	});
+
+	/**
+	 * Send a message to a Twitch chat channel as the user specified in the config file.
+	 * @param {String} channel - The name of the channel to send a message to. Do not include a leading "#" character.
+	 * @param {String} message - The message to send.
+	 * @param {Function} fn - The callback to execute after successfully sending the message.
+	 */
+	socket.on('say', (channel, message, fn) => {
+		chatClient.say(channel, message).then(() => {
+			fn(null, null);
+		}).catch(error => {
+			log.error(`Error attempting to "say" in channel "${channel}".\n\tMessage: ${message}\n\t`, error);
+			fn(error);
+		});
+	});
+
+	/**
+	 * Timeout a user in a Twitch chat channel for a given number of seconds.
+	 * @param {String} channel - The name of the channel to execute the timeout command in.
+	 * Do not include a leading "#" character.
+	 * @param {String} username - The name of the user to timeout.
+	 * @param {Number} seconds - The number of seconds to time the user out for.
+	 * @param {Function} fn - The callback to execute after successfully timing out the user.
+	 */
+	socket.on('timeout', (channel, username, seconds, fn) => {
+		chatClient.timeout(channel, username, seconds).then(() => {
+			fn(null, null);
+		}).catch(error => {
+			log.error(`Error attempting to timeout user "${username}" in channel "${channel}" for ${seconds} seconds.\n\t`, error);
+			fn(error);
+		});
+	});
+
+	/**
+	 * Get the list of chat mods for a Twitch channel.
+	 * @param {String} channel - The Twitch channel to get a list of chat mods from
+	 * @param {Function} fn - The callback to execute after successfully obtaining the list of chat mods.
+	 */
+	socket.on('mods', (channel, fn) => {
+		chatClient.mods(channel).then(mods => {
+			fn(null, mods);
+		}).catch(error => {
+			log.error(`Error attempting to get list of mods in channel "${channel}".\n\t`, error);
+			fn(error);
+		});
+	});
+
+	/**
+	 * Tell Streen that you wish for it to remain in this array of channels.
+	 * @param {Array.<string>} channels - The array of channel names. Do not include leading "#" characters.
+	 * @param {heartbeatCallback} fb - The callback to execute after the heartbeat has been registered.
+	 */
+	socket.on('heartbeat', (channels, fn) => {
+		client.heartbeat(channels);
+		fn(null, HEARTBEAT_TIMEOUT);
+	});
+
+	/**
+	 * The type of callback to execute after a successful heartbeat request.
+	 * @callback heartbeatCallback
+	 * @param {Object} err - The error returned, if any.
+	 * @param {Number} heartbeatTimeout - How long to wait (in milliseconds) before sending the next heartbeat.
+	 * Heartbeats can be sent earlier or later if needed.
+	 * A siphon has up to (heartbeatTimeout * 2 + 1000) milliseconds to
+	 * send another heartbeat before it times out. In other words, it can only miss
+	 * one consecutive heartbeat.
+	 */
+}

--- a/lib/twitch_chat.js
+++ b/lib/twitch_chat.js
@@ -229,6 +229,10 @@ class TwitchChatClient {
 	 * @param {*} channels
 	 */
 	heartbeat(channels) {
+		if (!this.connected) {
+			return;
+		}
+
 		const chatClient = this.chatClient;
 
 		// If we're not in any of these channels, join them.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "static": "eslint server.js lib/**/*.js",
-    "test": "npm run static && nyc ava --timeout=20s",
+    "test": "npm run static && nyc ava --timeout=20s --serial",
     "start": "node server.js",
     "create_migration": "pg-migrate create",
     "migrate": "pg-migrate up"

--- a/server.js
+++ b/server.js
@@ -1,21 +1,8 @@
-'use strict';
-
-const config = require('./lib/config');
 const log = require('./lib/log');
+const config = require('./lib/config');
 const format = require('util').format;
-const app = require('express')();
-const server = require('http').Server(app); // eslint-disable-line new-cap
-const io = require('socket.io')(server);
 const TwitchChatClient = require('./lib/twitch_chat');
-
-app.get('/', (req, res) => {
-	res.sendStatus(200);
-});
-
-const HEARTBEAT_TIMEOUT = 15 * 1000;
-const authenticatedSockets = new WeakSet();
-
-module.exports = {app, io, HEARTBEAT_TIMEOUT};
+const {io, HEARTBEAT_TIMEOUT, setupServer} = require('./lib/server');
 
 // Wait until we've defined module.exports before loading the Twitch IRC and Slack libs
 const slack = (function () {
@@ -52,140 +39,18 @@ process.on('SIGINT', () => {
 // Create the TwitchChatClient, restrieve the internal tmi client, and connect to twitch
 const client = new TwitchChatClient(io, HEARTBEAT_TIMEOUT, slack.status.bind(slack));
 const chatClient = client.chatClient;
-client.connect().then(() => {
-	setupServer();
-});
 
 // register the twitch chat client to slack (if enabled)
 slack.register(chatClient);
 
-function setupServer() {
-	io.on('connection', socket => {
-		log.trace('Socket %s connected.', socket.id);
+const twitchClientConnected = client.connect();
+const delayPromise = new Promise(resolve => {
+	setTimeout(() => resolve(), 1000);
+});
 
-		socket.on('authenticate', (key, fn) => {
-			log.debug('Socket %s authenticating with key "%s"', socket.id, key);
-
-			if (authenticatedSockets.has(socket)) {
-				log.debug('Already authenticated');
-				fn('already authenticated');
-				return;
-			}
-
-			if (key === config.get('secretKey')) {
-				log.debug('Accepted key');
-				setupAuthenticatedSocket(socket);
-				fn(null);
-			} else {
-				log.info('Rejected key "%s"', key);
-				fn('invalid key');
-			}
-		});
-	});
-
-	log.info('Socket.IO server initialized');
-
-	server.listen(config.get('port'));
-	log.info('Streen running on http://localhost:%s', config.get('port'));
-}
-
-function setupAuthenticatedSocket(socket) {
-	authenticatedSockets.add(socket);
-
-	/**
-	 * Join a Twitch chat channel.
-	 * @param {String} channel - The name of the channel to join. Do not include a leading "#" character.
-	 * @param {Function} fn - The callback to execute after successfully joining the channel.
-	 */
-	socket.on('join', (channel, fn) => {
-		log.debug('Socket %s requesting to join Twitch chat channel "%s"', socket.id, channel);
-		client.resetHeartbeat(channel);
-
-		// NOTE 2/1/2017: Rooms are only left when the socket itself is closed. Is this okay? Is this a leak?
-		// Have the socket join the namespace for the channel in order to receive messages.
-		const roomName = `channel:${channel}`;
-		if (Object.keys(socket.rooms).indexOf(roomName) < 0) {
-			log.trace('Socket %s joined room:', socket.id, roomName);
-			socket.join(roomName);
-		}
-
-		if (chatClient.channels.indexOf(`#${channel}`) >= 0) {
-			// Already in channel, invoke callback with the name
-			fn(null, channel);
-		} else {
-			chatClient.join(channel).then(() => {
-				fn(null, null);
-			}).catch(error => {
-				log.error(`Error attempting to join "${channel}" from join command.\n\t`, error);
-				fn(error);
-			});
-		}
-	});
-
-	/**
-	 * Send a message to a Twitch chat channel as the user specified in the config file.
-	 * @param {String} channel - The name of the channel to send a message to. Do not include a leading "#" character.
-	 * @param {String} message - The message to send.
-	 * @param {Function} fn - The callback to execute after successfully sending the message.
-	 */
-	socket.on('say', (channel, message, fn) => {
-		chatClient.say(channel, message).then(() => {
-			fn(null, null);
-		}).catch(error => {
-			log.error(`Error attempting to "say" in channel "${channel}".\n\tMessage: ${message}\n\t`, error);
-			fn(error);
-		});
-	});
-
-	/**
-	 * Timeout a user in a Twitch chat channel for a given number of seconds.
-	 * @param {String} channel - The name of the channel to execute the timeout command in.
-	 * Do not include a leading "#" character.
-	 * @param {String} username - The name of the user to timeout.
-	 * @param {Number} seconds - The number of seconds to time the user out for.
-	 * @param {Function} fn - The callback to execute after successfully timing out the user.
-	 */
-	socket.on('timeout', (channel, username, seconds, fn) => {
-		chatClient.timeout(channel, username, seconds).then(() => {
-			fn(null, null);
-		}).catch(error => {
-			log.error(`Error attempting to timeout user "${username}" in channel "${channel}" for ${seconds} seconds.\n\t`, error);
-			fn(error);
-		});
-	});
-
-	/**
-	 * Get the list of chat mods for a Twitch channel.
-	 * @param {String} channel - The Twitch channel to get a list of chat mods from
-	 * @param {Function} fn - The callback to execute after successfully obtaining the list of chat mods.
-	 */
-	socket.on('mods', (channel, fn) => {
-		chatClient.mods(channel).then(mods => {
-			fn(null, mods);
-		}).catch(error => {
-			log.error(`Error attempting to get list of mods in channel "${channel}".\n\t`, error);
-			fn(error);
-		});
-	});
-
-	/**
-	 * Tell Streen that you wish for it to remain in this array of channels.
-	 * @param {Array.<string>} channels - The array of channel names. Do not include leading "#" characters.
-	 * @param {heartbeatCallback} fb - The callback to execute after the heartbeat has been registered.
-	 */
-	socket.on('heartbeat', (channels, fn) => {
-		client.heartbeat(channels);
-		fn(null, HEARTBEAT_TIMEOUT);
-	});
-
-	/**
-	 * The type of callback to execute after a successful heartbeat request.
-	 * @callback heartbeatCallback
-	 * @param {Object} err - The error returned, if any.
-	 * @param {Number} heartbeatTimeout - How long to wait (in milliseconds) before sending the next heartbeat.
-	 * Heartbeats can be sent earlier or later if needed.
-	 * A siphon has up to (heartbeatTimeout * 2 + 1000) milliseconds to
-	 * send another heartbeat before it times out. In other words, it can only miss
-	 * one consecutive heartbeat.
-	 */
-}
+// Start the socket server after either connected to twitch, or after one second.
+// Prevents race conditions on server restart.
+Promise.race([twitchClientConnected, delayPromise]).then(
+	() => setupServer(client),
+	() => setupServer(client)
+);

--- a/test/test.js
+++ b/test/test.js
@@ -1,41 +1,37 @@
 import test from 'ava';
-import TwitchChatClient from '../lib/twitch_chat'
 
 const config = require('../lib/config');
+const {io, HEARTBEAT_TIMEOUT, setupServer } = require('../lib/server.js');
+const TwitchChatClient = require('../lib/twitch_chat');
+
 const CHANNELS = ['ghentbot'];
 let globalSocket;
 let tmiClient;
 
 test.before.cb(t => {
-	const server = require('../server.js');
-	globalSocket = require('socket.io-client')(`http://localhost:${config.get('port')}`);
+	const client = new TwitchChatClient(io, HEARTBEAT_TIMEOUT, () => {});
+	tmiClient = client.chatClient;
 
-	let socketConnected = false;
-	let tmiClientConnected = false;
-	globalSocket.on('connect', () => {
-		socketConnected = true;
-		checkDone();
+	// Currently in travis, it does not have a config and thus the twitch chat client never connects.
+	// So these tests have to work even if there is no actual config.
+	// This absolutely needs a refactor but its legacy so here it stays.
+	// Mock a "connected" tmi client that always succeeds joining
+	Object.defineProperty(client, 'connected', {
+		get: () => true
 	});
 
-	const client = new TwitchChatClient(server.io, server.HEARTBEAT_TIMEOUT, () => {});
-	tmiClient = client.chatClient;
-	client.connect();
-	if (tmiClient.readyState().toUpperCase() === 'OPEN') {
-		tmiClientConnected = true;
-		checkDone();
-	} else {
-		tmiClient.once('connected', () => {
-			tmiClientConnected = true;
-			checkDone();
-		});
-	}
+	tmiClient.join = function () {
+		return Promise.resolve();
+	};
 
-	function checkDone() {
-		if (socketConnected && tmiClientConnected) {
-			console.log('Done with setup, commencing tests.');
-			t.end();
-		}
-	}
+	setupServer(client);
+
+	globalSocket = require('socket.io-client')(`http://localhost:${config.get('port')}`);
+
+	globalSocket.on('connect', () => {
+		console.log('Done with setup, commencing tests.');
+		t.end();
+	});
 });
 
 test.cb('reject invalid authentication key', t => {


### PR DESCRIPTION
Last commit made travis fail. Basically travis does not connect to twitch at all, and the previous code made reasonable assumptions that there would be an open connection.

This splits the server.js, allowing a custom twitch chat client to be assigned. The test now mocks certain behavior of the twitch chat client so that it can pretend to be connected.

Also, streen will always start up even if twitch fails to connect, however it will have a delayed startup to give a chance to the twitch client to connect. This is necessary to avoid race conditions with lfg-siphon, where it will immediately try to join channels as soon as it connects to streen, even if streen is not ready to allow channel joining.

A true fix would require a tweak to lfg-siphon as well as a new event type, and this minor tweak should hopefully be good enough.